### PR TITLE
Add link to the API documentation in the nav bar

### DIFF
--- a/index.html
+++ b/index.html
@@ -31,6 +31,7 @@
                            <ul class="dropdown-menu" role="menu">
                               <li><a href="https://github.com/dokan-dev/dokany/blob/master/README.md">Getting Started</a></li>
                               <li><a href="https://github.com/dokan-dev/dokany/wiki">Wiki</a></li>
+                              <li><a href="https://dokan-dev.github.io/dokany-doc/html">API Documentation</a></li>
                               <li class="divider"></li>
                               <li class="dropdown-header">Discussion</li>
                               <li><a href="https://github.com/dokan-dev/dokany/issues">Issues</a></li>


### PR DESCRIPTION
This is something that bugged me for a long time. 

The landing page of Dokan project does not offer direct way to read the documentation. Since this is one of the most important parts about this project (how to develop your own filesystem if you don't know how?), there should be a driect link to the API for interested developers.

#### Motivation
I need to consider the Dokan API a lot and due to some laziness of myself i always went over the dokan project landing page to the documentation (via the wiki entry). I consider this a detour because, since the API is so important.

#### Changes
I added a link to dokan-dev/dokany-doc with the Label "API Documentation" in the "Getting Help" drop down menu in the nav bar.

What may be debatable is, if this should be a seperate entry in the nav-bar or not. 